### PR TITLE
Fix PATCH /order response parsing and bump to 2.2.5

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,11 +1,11 @@
 object Application {
     const val versionMajor = 2
     const val versionMinor = 2
-    const val versionPatch = 4
+    const val versionPatch = 5
 
     const val versionName = "${versionMajor}.${versionMinor}.$versionPatch"
     const val applicationId = "com.bunbeauty.fooddeliveryadmin"
-    const val versionCode = 224
+    const val versionCode = 225
 }
 
 object Namespace {

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
@@ -142,7 +142,7 @@ interface FoodDeliveryApi {
         token: String,
         orderUuid: String,
         status: OrderStatus,
-    ): ApiResult<OrderDetailsServer>
+    ): ApiResult<OrderServer>
 
     suspend fun getWorkInfo(companyUuid: String): ApiResult<WorkInfoData>
 

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
@@ -279,7 +279,7 @@ class FoodDeliveryApiImpl(
         token: String,
         orderUuid: String,
         status: OrderStatus,
-    ): ApiResult<OrderDetailsServer> =
+    ): ApiResult<OrderServer> =
         patch(
             path = "order",
             body = mapOf("status" to status.toString()),

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/OrderRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/OrderRepository.kt
@@ -28,7 +28,13 @@ class OrderRepository(
         orderUuid: String,
         status: OrderStatus,
     ) {
-        foodDeliveryApi.updateOrderStatus(token, orderUuid, status)
+        when (val result = foodDeliveryApi.updateOrderStatus(token, orderUuid, status)) {
+            is ApiResult.Success -> Unit
+            is ApiResult.Error -> {
+                println("$ORDER_TAG: updateStatus ${result.apiError.message} ${result.apiError.code}")
+                throw ServerConnectionException()
+            }
+        }
     }
 
     override suspend fun unsubscribeOrderUpdates(message: String) {

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsRoute.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsRoute.kt
@@ -156,7 +156,7 @@ private fun OrderDetailsEffect(
                 }
 
                 is OrderDetailsState.Event.ShowErrorMessage -> {
-                    showErrorMessage("Ошибка")
+                    showErrorMessage(getString(effect.messageResource))
                 }
 
                 OrderDetailsState.Event.GoBackEvent -> {

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsViewModel.kt
@@ -8,6 +8,8 @@ import com.bunbeauty.domain.model.order.details.OrderDetails
 import com.bunbeauty.shared.extension.launchSafe
 import com.bunbeauty.shared.feature.order.state.OrderDetailsState
 import com.bunbeauty.shared.viewmodel.base.BaseStateViewModel
+import fooddeliveryadmin.shared.generated.resources.Res
+import fooddeliveryadmin.shared.generated.resources.error_order_details_can_not_save
 
 class OrderDetailsViewModel(
     private val loadOrderDetails: LoadOrderDetailsUseCase,
@@ -179,12 +181,14 @@ class OrderDetailsViewModel(
                 }
             },
             onError = {
-                // TODO SET STRING
-//                sendEvent {
-//                    OrderDetailsState.Event.ShowErrorMessage(
-//                        messageId = Res.string.error_order_details_can_not_save
-//                    )
-//                }
+                setState {
+                    copy(saving = false)
+                }
+                sendEvent {
+                    OrderDetailsState.Event.ShowErrorMessage(
+                        messageResource = Res.string.error_order_details_can_not_save,
+                    )
+                }
             },
         )
     }

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/state/OrderDetailsState.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/state/OrderDetailsState.kt
@@ -5,6 +5,7 @@ import com.bunbeauty.domain.model.order.details.OrderDetails
 import com.bunbeauty.shared.viewmodel.base.BaseAction
 import com.bunbeauty.shared.viewmodel.base.BaseDataState
 import com.bunbeauty.shared.viewmodel.base.BaseEvent
+import org.jetbrains.compose.resources.StringResource
 
 interface OrderDetailsState {
     data class DataState(
@@ -47,7 +48,7 @@ interface OrderDetailsState {
         data object OpenWarningDialogEvent : Event
 
         data class ShowErrorMessage(
-            val messageId: Int,
+            val messageResource: StringResource,
         ) : Event
 
         data object GoBackEvent : Event


### PR DESCRIPTION
## Summary
- Fix NON_FATAL MissingFieldException on PATCH /order: client expected OrderDetailsServer, API returns GetCafeOrder
- updateOrderStatus now parses ApiResult<OrderServer>; repository propagates errors
- Show error snackbar on failed status save, reset saving state
- Bump version 2.2.5 (225)

## Test plan
- [ ] Open order details and change status — saves without Crashlytics parsing errors
- [ ] Simulate network/API error on save — error message shown, button not stuck loading
- [ ] Verify app version 2.2.5 (225)