### PR TITLE
Add YC storage credentials to CI and bump version to 2.2.6

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -26,11 +26,17 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          YC_ACCESS_KEY: ${{ secrets.YC_ACCESS_KEY }}
+          YC_SECRET_KEY: ${{ secrets.YC_SECRET_KEY }}
+          YC_BUCKET: ${{ secrets.YC_BUCKET }}
         run: |
           echo -e "RELEASE_STORE_FILE=$RELEASE_STORE_FILE" > local.properties
           echo -e "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" >> local.properties
           echo -e "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> local.properties
           echo -e "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> local.properties
+          echo -e "yc.accessKey=$YC_ACCESS_KEY" >> local.properties
+          echo -e "yc.secretKey=$YC_SECRET_KEY" >> local.properties
+          echo -e "yc.bucket=$YC_BUCKET" >> local.properties
       - name: "Upload local.properties"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -30,11 +30,17 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          YC_ACCESS_KEY: ${{ secrets.YC_ACCESS_KEY }}
+          YC_SECRET_KEY: ${{ secrets.YC_SECRET_KEY }}
+          YC_BUCKET: ${{ secrets.YC_BUCKET }}
         run: |
           echo -e "RELEASE_STORE_FILE=$RELEASE_STORE_FILE" > local.properties
           echo -e "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" >> local.properties
           echo -e "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> local.properties
           echo -e "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> local.properties
+          echo -e "yc.accessKey=$YC_ACCESS_KEY" >> local.properties
+          echo -e "yc.secretKey=$YC_SECRET_KEY" >> local.properties
+          echo -e "yc.bucket=$YC_BUCKET" >> local.properties
       - name: "Upload local.properties"
         uses: actions/upload-artifact@v4
         with:

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,11 +1,11 @@
 object Application {
     const val versionMajor = 2
     const val versionMinor = 2
-    const val versionPatch = 5
+    const val versionPatch = 6
 
     const val versionName = "${versionMajor}.${versionMinor}.$versionPatch"
     const val applicationId = "com.bunbeauty.fooddeliveryadmin"
-    const val versionCode = 225
+    const val versionCode = 226
 }
 
 object Namespace {


### PR DESCRIPTION
## Summary
- Прокинуты yc.accessKey, yc.secretKey, yc.bucket из GitHub Secrets в local.properties при CI/CD
- Исправлена загрузка фото в release-сборке (раньше BuildConfig содержал пустые строки)
- Версия: 2.2.6 (versionCode 226)

## Manual setup (обязательно до release в master)
Добавить в GitHub → Settings → Secrets and variables → Actions:
- YC_ACCESS_KEY
- YC_SECRET_KEY
- YC_BUCKET
Значения из локального local.properties (yc.accessKey, yc.secretKey, yc.bucket)

## Test plan
- [ ] Secrets добавлены в GitHub
- [ ] PR workflow зелёный
- [ ] После merge в master — publish workflow успешен
- [ ] В release-сборке загрузка фото работает