### PR TITLE
release/2.2.6

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -26,11 +26,17 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          YC_ACCESS_KEY: ${{ secrets.YC_ACCESS_KEY }}
+          YC_SECRET_KEY: ${{ secrets.YC_SECRET_KEY }}
+          YC_BUCKET: ${{ secrets.YC_BUCKET }}
         run: |
           echo -e "RELEASE_STORE_FILE=$RELEASE_STORE_FILE" > local.properties
           echo -e "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" >> local.properties
           echo -e "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> local.properties
           echo -e "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> local.properties
+          echo -e "yc.accessKey=$YC_ACCESS_KEY" >> local.properties
+          echo -e "yc.secretKey=$YC_SECRET_KEY" >> local.properties
+          echo -e "yc.bucket=$YC_BUCKET" >> local.properties
       - name: "Upload local.properties"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -30,11 +30,17 @@ jobs:
           RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          YC_ACCESS_KEY: ${{ secrets.YC_ACCESS_KEY }}
+          YC_SECRET_KEY: ${{ secrets.YC_SECRET_KEY }}
+          YC_BUCKET: ${{ secrets.YC_BUCKET }}
         run: |
           echo -e "RELEASE_STORE_FILE=$RELEASE_STORE_FILE" > local.properties
           echo -e "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD" >> local.properties
           echo -e "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS" >> local.properties
           echo -e "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD" >> local.properties
+          echo -e "yc.accessKey=$YC_ACCESS_KEY" >> local.properties
+          echo -e "yc.secretKey=$YC_SECRET_KEY" >> local.properties
+          echo -e "yc.bucket=$YC_BUCKET" >> local.properties
       - name: "Upload local.properties"
         uses: actions/upload-artifact@v4
         with:

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,11 +1,11 @@
 object Application {
     const val versionMajor = 2
     const val versionMinor = 2
-    const val versionPatch = 5
+    const val versionPatch = 6
 
     const val versionName = "${versionMajor}.${versionMinor}.$versionPatch"
     const val applicationId = "com.bunbeauty.fooddeliveryadmin"
-    const val versionCode = 225
+    const val versionCode = 226
 }
 
 object Namespace {

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/OrderRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/OrderRepository.kt
@@ -23,13 +23,29 @@ class OrderRepository(
     private val orderUpdatesWebSocket: OrderUpdatesWebSocket,
     private val serverOrderMapper: IServerOrderMapper,
 ) : OrderRepo {
+    private var orderListCache: List<Order>? = null
+    private var orderDetailsCache: MutableMap<String, OrderDetails> = mutableMapOf()
+
     override suspend fun updateStatus(
         token: String,
         orderUuid: String,
         status: OrderStatus,
     ) {
         when (val result = foodDeliveryApi.updateOrderStatus(token, orderUuid, status)) {
-            is ApiResult.Success -> Unit
+            is ApiResult.Success -> {
+                orderListCache =
+                    orderListCache?.map { order ->
+                        if (order.uuid == orderUuid) {
+                            order.copy(orderStatus = status)
+                        } else {
+                            order
+                        }
+                    }
+                orderDetailsCache[orderUuid]?.let { details ->
+                    orderDetailsCache[orderUuid] = details.copy(status = status)
+                }
+            }
+
             is ApiResult.Error -> {
                 println("$ORDER_TAG: updateStatus ${result.apiError.message} ${result.apiError.code}")
                 throw ServerConnectionException()
@@ -77,6 +93,7 @@ class OrderRepository(
                                     orderList = currentList,
                                     newOrder = order,
                                 )
+                            orderListCache = currentList
                             emit(OrderUpdatesStreamEvent.Orders(list = currentList))
                         }
                     }
@@ -92,11 +109,14 @@ class OrderRepository(
                 result.data
                     .results
                     .map(serverOrderMapper::mapOrder)
+                    .also { orderList ->
+                        orderListCache = orderList
+                    }
             }
 
             is ApiResult.Error -> {
                 println("$ORDER_TAG: getOrderListByCafeUuid ${result.apiError.message} ${result.apiError.code}")
-                throw ServerConnectionException()
+                orderListCache ?: throw ServerConnectionException()
             }
         }
 
@@ -106,17 +126,22 @@ class OrderRepository(
     ): OrderDetails? =
         when (val result = foodDeliveryApi.getOrderByUuid(token, orderUuid)) {
             is ApiResult.Success -> {
-                serverOrderMapper.mapOrderDetails(result.data)
+                serverOrderMapper
+                    .mapOrderDetails(result.data)
+                    .also { orderDetails ->
+                        orderDetailsCache[orderUuid] = orderDetails
+                    }
             }
 
             is ApiResult.Error -> {
                 println("$ORDER_TAG: loadOrderByUuid ${result.apiError.message} ${result.apiError.code}")
-                null
+                orderDetailsCache[orderUuid]
             }
         }
 
     override fun clearCache() {
-        // no-op (stream state is per collector)
+        orderListCache = null
+        orderDetailsCache.clear()
     }
 
     private fun updateOrderList(


### PR DESCRIPTION
## Release 2.2.6 (versionCode 226)

### Changes
- Fix: Yandex Object Storage credentials (`YC_ACCESS_KEY`, `YC_SECRET_KEY`, `YC_BUCKET`) are now injected into CI-generated `local.properties` during publish and PR workflows
- Fixes photo upload in release builds (BuildConfig previously had empty YC keys on CI)

### Prerequisites before merge
- [x] PR #160 merged to develop
- [ ] Add GitHub Actions secrets: `YC_ACCESS_KEY`, `YC_SECRET_KEY`, `YC_BUCKET` (values from local `local.properties`: `yc.accessKey`, `yc.secretKey`, `yc.bucket`)

### Test plan
- [ ] GitHub secrets configured
- [ ] Publish workflow succeeds on master push
- [ ] Photo upload works in release build