### PR TITLE
Add GetClientUserListUseCase for company client list

### DIFF
--- a/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
@@ -17,6 +17,7 @@ import com.bunbeauty.data.model.server.category.CategoryServer
 import com.bunbeauty.data.model.server.category.CreateCategoryPostServer
 import com.bunbeauty.data.model.server.category.PatchCategoryList
 import com.bunbeauty.data.model.server.city.CityServer
+import com.bunbeauty.data.model.server.clientuser.ClientUserSettingsServer
 import com.bunbeauty.data.model.server.company.CompanyPatchServer
 import com.bunbeauty.data.model.server.company.WorkInfoData
 import com.bunbeauty.data.model.server.menuProductToAdditionGroup.MenuProductToAdditionGroupServer
@@ -59,6 +60,13 @@ interface FoodDeliveryApi {
         updateUnlimitedNotificationRequest: UpdateUnlimitedNotificationRequest,
         token: String,
     ): ApiResult<Unit>
+
+    // CLIENT USER
+    suspend fun getClientUserList(
+        token: String,
+        limit: Int,
+        offset: Int,
+    ): ApiResult<ServerList<ClientUserSettingsServer>>
 
     // CAFE
     suspend fun getCafeList(cityUuid: String): ApiResult<ServerList<CafeServer>>

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/di/MapperModule.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/di/MapperModule.kt
@@ -5,6 +5,7 @@ import com.bunbeauty.data.mapper.OderProductMapper
 import com.bunbeauty.data.mapper.cafe.CafeMapper
 import com.bunbeauty.data.mapper.category.CategoryMapper
 import com.bunbeauty.data.mapper.city.CityMapper
+import com.bunbeauty.data.mapper.clientuser.ClientUserSettingsMapper
 import com.bunbeauty.data.mapper.nonworkingday.NonWorkingDayMapper
 import com.bunbeauty.data.mapper.order.IServerOrderMapper
 import com.bunbeauty.data.mapper.order.ServerOrderMapper
@@ -31,6 +32,8 @@ fun mapperModule() =
         single { OderProductMapper() }
 
         single { CityMapper() }
+
+        single { ClientUserSettingsMapper() }
 
         single {
             StatisticMapper()

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/di/RepoModule.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/di/RepoModule.kt
@@ -6,6 +6,7 @@ import com.bunbeauty.data.repository.AdditionRepository
 import com.bunbeauty.data.repository.CafeRepository
 import com.bunbeauty.data.repository.CategoryRepository
 import com.bunbeauty.data.repository.CityRepository
+import com.bunbeauty.data.repository.ClientUserRepository
 import com.bunbeauty.data.repository.CompanyRepository
 import com.bunbeauty.data.repository.FoodDeliveryApiImpl
 import com.bunbeauty.data.repository.MenuProductRepository
@@ -23,6 +24,7 @@ import com.bunbeauty.domain.repo.AdditionRepo
 import com.bunbeauty.domain.repo.CafeRepo
 import com.bunbeauty.domain.repo.CategoryRepo
 import com.bunbeauty.domain.repo.CityRepo
+import com.bunbeauty.domain.repo.ClientUserRepo
 import com.bunbeauty.domain.repo.CompanyRepo
 import com.bunbeauty.domain.repo.MenuProductRepo
 import com.bunbeauty.domain.repo.MenuProductToAdditionGroupRepository
@@ -83,6 +85,12 @@ fun repositoryModule() =
             CityRepository(
                 cityMapper = get(),
                 foodDeliveryApi = get(),
+            )
+        }
+        single<ClientUserRepo> {
+            ClientUserRepository(
+                foodDeliveryApi = get(),
+                clientUserSettingsMapper = get(),
             )
         }
         single<NonWorkingDayRepo> {

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserSettingsMapper.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserSettingsMapper.kt
@@ -1,0 +1,14 @@
+package com.bunbeauty.data.mapper.clientuser
+
+import com.bunbeauty.data.model.server.clientuser.ClientUserSettingsServer
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettings
+
+class ClientUserSettingsMapper {
+    fun map(clientUserSettingsServer: ClientUserSettingsServer): ClientUserSettings =
+        ClientUserSettings(
+            uuid = clientUserSettingsServer.uuid,
+            phoneNumber = clientUserSettingsServer.phoneNumber,
+            email = clientUserSettingsServer.email,
+            isActive = clientUserSettingsServer.isActive,
+        )
+}

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserSettingsServer.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserSettingsServer.kt
@@ -1,0 +1,11 @@
+package com.bunbeauty.data.model.server.clientuser
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClientUserSettingsServer(
+    val uuid: String,
+    val phoneNumber: String,
+    val email: String?,
+    val isActive: Boolean,
+)

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
@@ -1,0 +1,37 @@
+package com.bunbeauty.data.repository
+
+import com.bunbeauty.data.FoodDeliveryApi
+import com.bunbeauty.data.mapper.clientuser.ClientUserSettingsMapper
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettingsList
+import com.bunbeauty.domain.repo.ClientUserRepo
+import common.ApiResult
+
+class ClientUserRepository(
+    private val foodDeliveryApi: FoodDeliveryApi,
+    private val clientUserSettingsMapper: ClientUserSettingsMapper,
+) : ClientUserRepo {
+    override suspend fun getClientUserList(
+        token: String,
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList =
+        when (
+            val result =
+                foodDeliveryApi.getClientUserList(
+                    token = token,
+                    limit = limit,
+                    offset = offset,
+                )
+        ) {
+            is ApiResult.Success -> {
+                ClientUserSettingsList(
+                    count = result.data.count,
+                    results = result.data.results.map(clientUserSettingsMapper::map),
+                )
+            }
+
+            is ApiResult.Error -> {
+                throw Exception("client user list load error")
+            }
+        }
+}

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
@@ -19,6 +19,7 @@ import com.bunbeauty.data.model.server.category.CategoryServer
 import com.bunbeauty.data.model.server.category.CreateCategoryPostServer
 import com.bunbeauty.data.model.server.category.PatchCategoryList
 import com.bunbeauty.data.model.server.city.CityServer
+import com.bunbeauty.data.model.server.clientuser.ClientUserSettingsServer
 import com.bunbeauty.data.model.server.company.CompanyPatchServer
 import com.bunbeauty.data.model.server.company.WorkInfoData
 import com.bunbeauty.data.model.server.menuProductToAdditionGroup.MenuProductToAdditionGroupServer
@@ -78,6 +79,21 @@ class FoodDeliveryApiImpl(
             token = token,
         )
 
+    override suspend fun getClientUserList(
+        token: String,
+        limit: Int,
+        offset: Int,
+    ): ApiResult<ServerList<ClientUserSettingsServer>> =
+        get(
+            path = "client/list",
+            parameters =
+                listOf(
+                    "limit" to limit.toString(),
+                    "offset" to offset.toString(),
+                ),
+            token = token,
+        )
+
     override suspend fun putNotificationToken(
         updateNotificationTokenRequest: UpdateNotificationTokenRequest,
         token: String,
@@ -124,6 +140,7 @@ class FoodDeliveryApiImpl(
         patch(
             path = "cafe",
             parameters = listOf("cafeUuid" to cafeUuid),
+
             body = patchCafe,
             token = token,
         )

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
@@ -140,7 +140,6 @@ class FoodDeliveryApiImpl(
         patch(
             path = "cafe",
             parameters = listOf("cafeUuid" to cafeUuid),
-
             body = patchCafe,
             token = token,
         )

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/GetClientUserListUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/GetClientUserListUseCase.kt
@@ -1,0 +1,21 @@
+package com.bunbeauty.domain.feature.clientuser
+
+import com.bunbeauty.domain.exception.NoTokenException
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettingsList
+import com.bunbeauty.domain.repo.ClientUserRepo
+import com.bunbeauty.domain.repo.DataStoreRepo
+
+class GetClientUserListUseCase(
+    private val clientUserRepo: ClientUserRepo,
+    private val dataStoreRepo: DataStoreRepo,
+) {
+    suspend operator fun invoke(
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList =
+        clientUserRepo.getClientUserList(
+            token = dataStoreRepo.getToken() ?: throw NoTokenException(),
+            limit = limit,
+            offset = offset,
+        )
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettings.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettings.kt
@@ -1,0 +1,8 @@
+package com.bunbeauty.domain.feature.clientuser.model
+
+data class ClientUserSettings(
+    val uuid: String,
+    val phoneNumber: String,
+    val email: String?,
+    val isActive: Boolean,
+)

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettingsList.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettingsList.kt
@@ -1,0 +1,6 @@
+package com.bunbeauty.domain.feature.clientuser.model
+
+data class ClientUserSettingsList(
+    val count: Int,
+    val results: List<ClientUserSettings>,
+)

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
@@ -1,0 +1,11 @@
+package com.bunbeauty.domain.repo
+
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettingsList
+
+interface ClientUserRepo {
+    suspend fun getClientUserList(
+        token: String,
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList
+}

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
@@ -1,6 +1,7 @@
 package com.bunbeauty.shared.di
 
 import com.bunbeauty.domain.feature.additiongrouplist.createadditiongrouplist.CreateAdditionGroupUseCase
+import com.bunbeauty.domain.feature.clientuser.GetClientUserListUseCase
 import com.bunbeauty.domain.feature.common.GetCafeUseCase
 import com.bunbeauty.domain.feature.menu.additiongroupformenuproduct.editadditiongroupformenuproduct.SaveEditAdditionGroupWithAdditionsUseCase
 import com.bunbeauty.domain.feature.menu.common.category.CreateCategoryUseCase
@@ -52,6 +53,13 @@ fun useCaseModule() =
             GetCategoryListUseCase(
                 dataStoreRepo = get(),
                 categoryRepo = get(),
+            )
+        }
+
+        factory {
+            GetClientUserListUseCase(
+                clientUserRepo = get(),
+                dataStoreRepo = get(),
             )
         }
 


### PR DESCRIPTION
## Summary

Adds data/domain layer support for loading company client users via `GetClientUserListUseCase`:
- Domain models `ClientUserSettings` / `ClientUserSettingsList` and `ClientUserRepo`
- `ClientUserRepository` with mapper from `ClientUserSettingsServer`
- `FoodDeliveryApi.getClientUserList` → `GET client/list` with `limit` / `offset` pagination
- Koin wiring in `MapperModule`, `RepoModule`, `UseCaseModule`

No UI changes in this PR.

## Backend note

`GET /client/list` returns **active clients only** (filtered on backend).

## How to test

1. Build the project (`./gradlew :shared:compileKotlinIosArm64` or Android assemble).
2. Resolve `GetClientUserListUseCase` from Koin after login (token in `DataStoreRepo`).
3. Call `getClientUserListUseCase(limit = 20, offset = 0)` and verify `ClientUserSettingsList` (`count`, `results`).
4. Optionally inspect network: authorized request to `client/list?limit=20&offset=0`.