### PR TITLE
Add GetClientUserSearchUseCase for client phone search

### DIFF
--- a/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
@@ -69,6 +69,13 @@ interface FoodDeliveryApi {
         offset: Int,
     ): ApiResult<ServerList<ClientUserSettingsServer>>
 
+    suspend fun getClientUserSearch(
+        token: String,
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): ApiResult<ServerList<ClientUserSettingsServer>>
+
     suspend fun getClientUserStatistic(
         token: String,
         clientUserUuid: String,

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
@@ -38,6 +38,33 @@ class ClientUserRepository(
             }
         }
 
+    override suspend fun getClientUserListByQuery(
+        token: String,
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList =
+        when (
+            val result =
+                foodDeliveryApi.getClientUserSearch(
+                    token = token,
+                    query = query,
+                    limit = limit,
+                    offset = offset,
+                )
+        ) {
+            is ApiResult.Success -> {
+                ClientUserSettingsList(
+                    count = result.data.count,
+                    results = result.data.results.map(clientUserSettingsMapper::map),
+                )
+            }
+
+            is ApiResult.Error -> {
+                throw Exception("client user search load error")
+            }
+        }
+
     override suspend fun getClientUserStatistic(
         token: String,
         clientUserUuid: String,

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
@@ -95,6 +95,23 @@ class FoodDeliveryApiImpl(
             token = token,
         )
 
+    override suspend fun getClientUserSearch(
+        token: String,
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): ApiResult<ServerList<ClientUserSettingsServer>> =
+        get(
+            path = "client/search",
+            parameters =
+                listOf(
+                    "query" to query,
+                    "limit" to limit.toString(),
+                    "offset" to offset.toString(),
+                ),
+            token = token,
+        )
+
     override suspend fun getClientUserStatistic(
         token: String,
         clientUserUuid: String,

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/GetClientUserSearchUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/GetClientUserSearchUseCase.kt
@@ -1,0 +1,23 @@
+package com.bunbeauty.domain.feature.clientuser
+
+import com.bunbeauty.domain.exception.NoTokenException
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettingsList
+import com.bunbeauty.domain.repo.ClientUserRepo
+import com.bunbeauty.domain.repo.DataStoreRepo
+
+class GetClientUserSearchUseCase(
+    private val clientUserRepo: ClientUserRepo,
+    private val dataStoreRepo: DataStoreRepo,
+) {
+    suspend operator fun invoke(
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList =
+        clientUserRepo.getClientUserListByQuery(
+            token = dataStoreRepo.getToken() ?: throw NoTokenException(),
+            query = query,
+            limit = limit,
+            offset = offset,
+        )
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
@@ -10,6 +10,13 @@ interface ClientUserRepo {
         offset: Int,
     ): ClientUserSettingsList
 
+    suspend fun getClientUserListByQuery(
+        token: String,
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): ClientUserSettingsList
+
     suspend fun getClientUserStatistic(
         token: String,
         clientUserUuid: String,

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.bunbeauty.shared.di
 
 import com.bunbeauty.domain.feature.additiongrouplist.createadditiongrouplist.CreateAdditionGroupUseCase
 import com.bunbeauty.domain.feature.clientuser.GetClientUserListUseCase
+import com.bunbeauty.domain.feature.clientuser.GetClientUserSearchUseCase
 import com.bunbeauty.domain.feature.clientuser.GetClientUserStatisticUseCase
 import com.bunbeauty.domain.feature.common.GetCafeUseCase
 import com.bunbeauty.domain.feature.menu.additiongroupformenuproduct.editadditiongroupformenuproduct.SaveEditAdditionGroupWithAdditionsUseCase
@@ -59,6 +60,13 @@ fun useCaseModule() =
 
         factory {
             GetClientUserListUseCase(
+                clientUserRepo = get(),
+                dataStoreRepo = get(),
+            )
+        }
+
+        factory {
+            GetClientUserSearchUseCase(
                 clientUserRepo = get(),
                 dataStoreRepo = get(),
             )


### PR DESCRIPTION
## Summary
- Mirrors the existing client list use case pattern for phone search
- Calls `GET /client/search` via domain/data layers
- No UI changes

## Test plan
- [ ] Confirm `GetClientUserSearchUseCase` is wired in `UseCaseModule`
- [ ] Smoke-check API path `client/search` with query/limit/offset