### PR TITLE
Show courier role in profile with DataStore cache

### DIFF
--- a/data/src/androidMain/kotlin/com/bunbeauty/data/repository/DataStoreRepository.kt
+++ b/data/src/androidMain/kotlin/com/bunbeauty/data/repository/DataStoreRepository.kt
@@ -54,6 +54,19 @@ class DataStoreRepository(
         }
     }
 
+    override val userRole =
+        context.userDataStore.data.map { preferences ->
+            preferences[USER_ROLE_KEY]
+        }
+
+    override suspend fun getUserRole(): String? = userRole.firstOrNull()
+
+    override suspend fun saveUserRole(userRole: String) {
+        context.userDataStore.edit { preferences ->
+            preferences[USER_ROLE_KEY] = userRole
+        }
+    }
+
     override val cafeUuid: Flow<String?> =
         context.cafeUuidDataStore.data.map {
             it[CAFE_UUID_KEY]
@@ -105,6 +118,7 @@ class DataStoreRepository(
 
         private const val TOKEN = "token"
         private const val USERNAME = "username"
+        private const val USER_ROLE = "user role"
         private const val COMPANY_UUID = "company uuid"
         private const val CAFE_UUID = "cafe uuid"
         private const val PREVIOUS_CAFE_UUID = "previous cafe uuid"
@@ -113,6 +127,7 @@ class DataStoreRepository(
         // KEYS
         private val TOKEN_KEY = stringPreferencesKey(TOKEN)
         private val USERNAME_KEY = stringPreferencesKey(USERNAME)
+        private val USER_ROLE_KEY = stringPreferencesKey(USER_ROLE)
         private val COMPANY_UUID_KEY = stringPreferencesKey(COMPANY_UUID)
         private val CAFE_UUID_KEY = stringPreferencesKey(CAFE_UUID)
         private val PREVIOUS_CAFE_UUID_KEY = stringPreferencesKey(PREVIOUS_CAFE_UUID)

--- a/data/src/androidUnitTest/kotlin/com/bunbeauty/data/repository/UserRepositoryTest.kt
+++ b/data/src/androidUnitTest/kotlin/com/bunbeauty/data/repository/UserRepositoryTest.kt
@@ -1,0 +1,81 @@
+package com.bunbeauty.data.repository
+
+import com.bunbeauty.data.FoodDeliveryApi
+import com.bunbeauty.data.model.server.user.UserResponse
+import com.bunbeauty.domain.exception.DataNotFoundException
+import com.bunbeauty.domain.feature.profile.model.UserRole
+import com.bunbeauty.domain.repo.DataStoreRepo
+import common.ApiResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserRepositoryTest {
+    private val dataStoreRepo: DataStoreRepo = mockk()
+    private val foodDeliveryApi: FoodDeliveryApi = mockk()
+
+    private val userRepository =
+        UserRepository(
+            dataStoreRepo = dataStoreRepo,
+            foodDeliveryApi = foodDeliveryApi,
+        )
+
+    @Test
+    fun `getUserRole returns cached role without network call`() =
+        runTest {
+            coEvery { dataStoreRepo.getUserRole() } returns "courier"
+
+            val result = userRepository.getUserRole()
+
+            assertEquals(UserRole.COURIER, result)
+            coVerify(exactly = 0) { foodDeliveryApi.getUser(any()) }
+        }
+
+    @Test
+    fun `getUserRole fetches and caches role when cache is empty`() =
+        runTest {
+            coEvery { dataStoreRepo.getUserRole() } returns null
+            coEvery { dataStoreRepo.getToken() } returns "token"
+            coEvery { foodDeliveryApi.getUser(token = "token") } returns
+                ApiResult.Success(
+                    UserResponse(
+                        uuid = "uuid",
+                        username = "courier_user",
+                        role = "courier",
+                        unlimitedNotification = true,
+                    ),
+                )
+            coEvery { dataStoreRepo.saveUserRole("courier") } returns Unit
+
+            val result = userRepository.getUserRole()
+
+            assertEquals(UserRole.COURIER, result)
+            coVerify(exactly = 1) { dataStoreRepo.saveUserRole("courier") }
+        }
+
+    @Test
+    fun `getUserRole throws when server role is unknown`() =
+        runTest {
+            coEvery { dataStoreRepo.getUserRole() } returns null
+            coEvery { dataStoreRepo.getToken() } returns "token"
+            coEvery { foodDeliveryApi.getUser(token = "token") } returns
+                ApiResult.Success(
+                    UserResponse(
+                        uuid = "uuid",
+                        username = "user",
+                        role = "unknown",
+                        unlimitedNotification = true,
+                    ),
+                )
+
+            assertThrows(DataNotFoundException::class.java) {
+                runBlocking { userRepository.getUserRole() }
+            }
+            coVerify(exactly = 0) { dataStoreRepo.saveUserRole(any()) }
+        }
+}

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/di/RepoModule.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/di/RepoModule.kt
@@ -16,6 +16,7 @@ import com.bunbeauty.data.repository.NonWorkingDayRepository
 import com.bunbeauty.data.repository.OrderRepository
 import com.bunbeauty.data.repository.SettingsRepository
 import com.bunbeauty.data.repository.StatisticRepository
+import com.bunbeauty.data.repository.UserRepository
 import com.bunbeauty.data.websocket.OrderUpdatesWebSocket
 import com.bunbeauty.data.websocket.OrderUpdatesWebSocketImpl
 import com.bunbeauty.domain.feature.order.OrderRepo
@@ -32,6 +33,7 @@ import com.bunbeauty.domain.repo.MenuProductToAdditionGroupToAdditionRepository
 import com.bunbeauty.domain.repo.NonWorkingDayRepo
 import com.bunbeauty.domain.repo.SettingsRepo
 import com.bunbeauty.domain.repo.StatisticRepo
+import com.bunbeauty.domain.repo.UserRepo
 import org.koin.dsl.module
 
 fun repositoryModule() =
@@ -112,6 +114,12 @@ fun repositoryModule() =
         }
         single<SettingsRepo> {
             SettingsRepository(
+                dataStoreRepo = get(),
+                foodDeliveryApi = get(),
+            )
+        }
+        single<UserRepo> {
+            UserRepository(
                 dataStoreRepo = get(),
                 foodDeliveryApi = get(),
             )

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/UserRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/UserRepository.kt
@@ -1,0 +1,32 @@
+package com.bunbeauty.data.repository
+
+import com.bunbeauty.data.FoodDeliveryApi
+import com.bunbeauty.data.extensions.dataOrNull
+import com.bunbeauty.domain.exception.DataNotFoundException
+import com.bunbeauty.domain.exception.NoTokenException
+import com.bunbeauty.domain.feature.profile.model.UserRole
+import com.bunbeauty.domain.repo.DataStoreRepo
+import com.bunbeauty.domain.repo.UserRepo
+
+class UserRepository(
+    private val dataStoreRepo: DataStoreRepo,
+    private val foodDeliveryApi: FoodDeliveryApi,
+) : UserRepo {
+    override suspend fun getUserRole(): UserRole {
+        val cachedRole = dataStoreRepo.getUserRole()
+        if (cachedRole != null) {
+            val mappedCachedRole = UserRole.fromServer(cachedRole)
+            if (mappedCachedRole != null) {
+                return mappedCachedRole
+            }
+        }
+
+        val token = dataStoreRepo.getToken() ?: throw NoTokenException()
+        val user = foodDeliveryApi.getUser(token = token).dataOrNull() ?: throw DataNotFoundException()
+        val role = UserRole.fromServer(user.role) ?: throw DataNotFoundException()
+
+        dataStoreRepo.saveUserRole(UserRole.toServer(role))
+
+        return role
+    }
+}

--- a/data/src/iosMain/kotlin/com/bunbeauty/data/di/IosDataStoreRepository.kt
+++ b/data/src/iosMain/kotlin/com/bunbeauty/data/di/IosDataStoreRepository.kt
@@ -12,6 +12,7 @@ class IosDataStoreRepository : DataStoreRepo {
     private val tokenState = MutableStateFlow<String?>(null)
     private val companyUuidState = MutableStateFlow("")
     private val usernameState = MutableStateFlow("")
+    private val userRoleState = MutableStateFlow<String?>(null)
     private val cafeUuidState = MutableStateFlow<String?>(null)
     private val previousCafeUuidState = MutableStateFlow<String?>(null)
     private val isUnlimitedNotificationState = MutableStateFlow(true)
@@ -43,6 +44,15 @@ class IosDataStoreRepository : DataStoreRepo {
         usernameState.value = username
     }
 
+    override val userRole: Flow<String?> = userRoleState.asStateFlow()
+
+    override suspend fun getUserRole(): String? = defaults.stringForKey(KEY_USER_ROLE)
+
+    override suspend fun saveUserRole(userRole: String) {
+        defaults.setObject(userRole, forKey = KEY_USER_ROLE)
+        userRoleState.value = userRole
+    }
+
     override val cafeUuid: Flow<String?> = cafeUuidState.asStateFlow()
 
     override suspend fun saveCafeUuid(cafeUuid: String) {
@@ -67,12 +77,14 @@ class IosDataStoreRepository : DataStoreRepo {
     override suspend fun clearCache() {
         defaults.removeObjectForKey(KEY_TOKEN)
         defaults.removeObjectForKey(KEY_USERNAME)
+        defaults.removeObjectForKey(KEY_USER_ROLE)
         defaults.removeObjectForKey(KEY_COMPANY_UUID)
         defaults.removeObjectForKey(KEY_CAFE_UUID)
         defaults.removeObjectForKey(KEY_PREVIOUS_CAFE_UUID)
         tokenState.value = null
         companyUuidState.value = ""
         usernameState.value = ""
+        userRoleState.value = null
         cafeUuidState.value = null
         previousCafeUuidState.value = null
     }
@@ -81,6 +93,7 @@ class IosDataStoreRepository : DataStoreRepo {
         tokenState.value = defaults.stringForKey(KEY_TOKEN)
         companyUuidState.value = defaults.stringForKey(KEY_COMPANY_UUID).orEmpty()
         usernameState.value = defaults.stringForKey(KEY_USERNAME).orEmpty()
+        userRoleState.value = defaults.stringForKey(KEY_USER_ROLE)
         cafeUuidState.value = defaults.stringForKey(KEY_CAFE_UUID)
         previousCafeUuidState.value = defaults.stringForKey(KEY_PREVIOUS_CAFE_UUID)
         isUnlimitedNotificationState.value = readIsUnlimitedNotificationFromDefaults()
@@ -106,6 +119,7 @@ class IosDataStoreRepository : DataStoreRepo {
 
         private val KEY_TOKEN = key(USER_DATA_STORE, "token")
         private val KEY_USERNAME = key(USER_DATA_STORE, "username")
+        private val KEY_USER_ROLE = key(USER_DATA_STORE, "user role")
         private val KEY_COMPANY_UUID = key(USER_DATA_STORE, "company uuid")
         private val KEY_CAFE_UUID = key(CAFE_UUID_DATA_STORE, "cafe uuid")
         private val KEY_PREVIOUS_CAFE_UUID = key(CAFE_UUID_DATA_STORE, "previous cafe uuid")

--- a/domain/src/androidUnitTest/kotlin/feature/profile/GetProfileUserUseCaseTest.kt
+++ b/domain/src/androidUnitTest/kotlin/feature/profile/GetProfileUserUseCaseTest.kt
@@ -1,0 +1,48 @@
+package test.feature.profile
+
+import com.bunbeauty.domain.exception.DataNotFoundException
+import com.bunbeauty.domain.feature.profile.GetProfileUserUseCase
+import com.bunbeauty.domain.feature.profile.model.UserRole
+import com.bunbeauty.domain.repo.DataStoreRepo
+import com.bunbeauty.domain.repo.UserRepo
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetProfileUserUseCaseTest {
+    private val dataStoreRepo: DataStoreRepo = mockk()
+    private val userRepo: UserRepo = mockk()
+
+    private val getProfileUserUseCase =
+        GetProfileUserUseCase(
+            dataStoreRepo = dataStoreRepo,
+            userRepo = userRepo,
+        )
+
+    @Test
+    fun `invoke should return profile user with role from repository`() =
+        runTest {
+            coEvery { dataStoreRepo.username } returns flowOf("courier_user")
+            coEvery { userRepo.getUserRole() } returns UserRole.COURIER
+
+            val result = getProfileUserUseCase()
+
+            assertEquals(UserRole.COURIER, result.role)
+            assertEquals("courier_user", result.userName)
+        }
+
+    @Test
+    fun `invoke should throw DataNotFoundException when username is blank`() =
+        runTest {
+            coEvery { dataStoreRepo.username } returns flowOf("")
+
+            assertThrows(DataNotFoundException::class.java) {
+                runBlocking { getProfileUserUseCase() }
+            }
+        }
+}

--- a/domain/src/androidUnitTest/kotlin/feature/profile/UserRoleTest.kt
+++ b/domain/src/androidUnitTest/kotlin/feature/profile/UserRoleTest.kt
@@ -1,0 +1,29 @@
+package test.feature.profile
+
+import com.bunbeauty.domain.feature.profile.model.UserRole
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserRoleTest {
+    @Test
+    fun `fromServer maps known roles`() {
+        assertEquals(UserRole.MANAGER, UserRole.fromServer("manager"))
+        assertEquals(UserRole.ADMIN, UserRole.fromServer("admin"))
+        assertEquals(UserRole.COURIER, UserRole.fromServer("courier"))
+        assertEquals(UserRole.COURIER, UserRole.fromServer("COURIER"))
+    }
+
+    @Test
+    fun `fromServer returns null for unknown role`() {
+        assertNull(UserRole.fromServer("unknown"))
+        assertNull(UserRole.fromServer("client"))
+    }
+
+    @Test
+    fun `toServer maps domain roles`() {
+        assertEquals("manager", UserRole.toServer(UserRole.MANAGER))
+        assertEquals("admin", UserRole.toServer(UserRole.ADMIN))
+        assertEquals("courier", UserRole.toServer(UserRole.COURIER))
+    }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/GetProfileUserUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/GetProfileUserUseCase.kt
@@ -1,0 +1,25 @@
+package com.bunbeauty.domain.feature.profile
+
+import com.bunbeauty.domain.exception.DataNotFoundException
+import com.bunbeauty.domain.feature.profile.model.ProfileUser
+import com.bunbeauty.domain.repo.DataStoreRepo
+import com.bunbeauty.domain.repo.UserRepo
+import kotlinx.coroutines.flow.firstOrNull
+
+class GetProfileUserUseCase(
+    private val dataStoreRepo: DataStoreRepo,
+    private val userRepo: UserRepo,
+) {
+    suspend operator fun invoke(): ProfileUser {
+        val userName =
+            dataStoreRepo.username.firstOrNull()?.takeIf { username ->
+                username.isNotBlank()
+            } ?: throw DataNotFoundException()
+        val role = userRepo.getUserRole()
+
+        return ProfileUser(
+            role = role,
+            userName = userName,
+        )
+    }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/di/ProfileModule.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/di/ProfileModule.kt
@@ -1,6 +1,7 @@
 package com.bunbeauty.domain.feature.profile.di
 
 import com.bunbeauty.domain.feature.profile.GetIsUnlimitedNotificationUseCase
+import com.bunbeauty.domain.feature.profile.GetProfileUserUseCase
 import com.bunbeauty.domain.feature.profile.GetUsernameUseCase
 import com.bunbeauty.domain.feature.profile.UpdateIsUnlimitedNotificationUseCase
 import com.bunbeauty.domain.feature.profile.model.GetTypeWorkUseCase
@@ -33,6 +34,13 @@ fun profileModule() =
         factory {
             GetUsernameUseCase(
                 dataStoreRepo = get(),
+            )
+        }
+
+        factory {
+            GetProfileUserUseCase(
+                dataStoreRepo = get(),
+                userRepo = get(),
             )
         }
 

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/model/ProfileUser.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/model/ProfileUser.kt
@@ -1,0 +1,6 @@
+package com.bunbeauty.domain.feature.profile.model
+
+data class ProfileUser(
+    val role: UserRole,
+    val userName: String,
+)

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/model/UserRole.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/profile/model/UserRole.kt
@@ -3,4 +3,23 @@ package com.bunbeauty.domain.feature.profile.model
 enum class UserRole {
     MANAGER,
     ADMIN,
+    COURIER,
+    ;
+
+    companion object {
+        fun fromServer(role: String): UserRole? =
+            when (role.lowercase()) {
+                "manager" -> MANAGER
+                "admin" -> ADMIN
+                "courier" -> COURIER
+                else -> null
+            }
+
+        fun toServer(role: UserRole): String =
+            when (role) {
+                MANAGER -> "manager"
+                ADMIN -> "admin"
+                COURIER -> "courier"
+            }
+    }
 }

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/DataStoreRepo.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/DataStoreRepo.kt
@@ -17,6 +17,12 @@ interface DataStoreRepo {
 
     suspend fun saveUsername(username: String)
 
+    val userRole: Flow<String?>
+
+    suspend fun getUserRole(): String?
+
+    suspend fun saveUserRole(userRole: String)
+
     val cafeUuid: Flow<String?>
 
     suspend fun saveCafeUuid(cafeUuid: String)

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/UserRepo.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/UserRepo.kt
@@ -1,0 +1,7 @@
+package com.bunbeauty.domain.repo
+
+import com.bunbeauty.domain.feature.profile.model.UserRole
+
+interface UserRepo {
+    suspend fun getUserRole(): UserRole
+}

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="title_profile">Профиль</string>
     <string name="hint_profile_manager">Менеджер</string>
     <string name="hint_profile_admin">Админ</string>
+    <string name="hint_profile_courier">Курьер</string>
     <string name="action_profile_cafes">Рестораны</string>
     <string name="action_profile_settings">Настройки</string>
     <string name="action_profile_statistic">Статистика</string>

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/ViewModelModule.kt
@@ -195,7 +195,7 @@ fun viewModelModule() =
 
         viewModel {
             ProfileViewModel(
-                getUsernameUseCase = get(),
+                getProfileUserUseCase = get(),
                 logoutUseCase = get(),
             )
         }

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/profile/ProfileViewModel.kt
@@ -1,14 +1,13 @@
 package com.bunbeauty.shared.feature.profile
 
 import androidx.lifecycle.viewModelScope
-import com.bunbeauty.domain.feature.profile.GetUsernameUseCase
-import com.bunbeauty.domain.feature.profile.model.UserRole
+import com.bunbeauty.domain.feature.profile.GetProfileUserUseCase
 import com.bunbeauty.domain.usecase.LogoutUseCase
 import com.bunbeauty.shared.extension.launchSafe
 import com.bunbeauty.shared.viewmodel.base.BaseStateViewModel
 
 class ProfileViewModel(
-    private val getUsernameUseCase: GetUsernameUseCase,
+    private val getProfileUserUseCase: GetProfileUserUseCase,
     private val logoutUseCase: LogoutUseCase,
 ) : BaseStateViewModel<Profile.DataState, Profile.Action, Profile.Event>(
         initState =
@@ -44,14 +43,15 @@ class ProfileViewModel(
     private fun handleUpdateData() {
         viewModelScope.launchSafe(
             block = {
+                val profileUser = getProfileUserUseCase()
                 setState {
                     copy(
                         state = Profile.DataState.State.SUCCESS,
                         user =
                             Profile.DataState.User(
-                                role = UserRole.MANAGER,
+                                role = profileUser.role,
                                 userName =
-                                    getUsernameUseCase().lowercase().replaceFirstChar { char ->
+                                    profileUser.userName.lowercase().replaceFirstChar { char ->
                                         char.uppercase()
                                     },
                             ),

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/profile/ProfileViewState.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/profile/ProfileViewState.kt
@@ -5,6 +5,7 @@ import com.bunbeauty.domain.feature.profile.model.UserRole
 import com.bunbeauty.shared.viewmodel.base.BaseViewState
 import fooddeliveryadmin.shared.generated.resources.Res
 import fooddeliveryadmin.shared.generated.resources.hint_profile_admin
+import fooddeliveryadmin.shared.generated.resources.hint_profile_courier
 import fooddeliveryadmin.shared.generated.resources.hint_profile_manager
 import org.jetbrains.compose.resources.stringResource
 
@@ -36,6 +37,7 @@ internal fun Profile.DataState.toViewState(): ProfileViewState =
                             when (user.role) {
                                 UserRole.MANAGER -> Res.string.hint_profile_manager
                                 UserRole.ADMIN -> Res.string.hint_profile_admin
+                                UserRole.COURIER -> Res.string.hint_profile_courier
                             }
                         ProfileViewState.State.Success(
                             role = stringResource(roleStringId),


### PR DESCRIPTION
## Summary
- Added COURIER to admin UserRole
- Fetch role via GET /user once, cache in DataStore, clear on logout
- Profile shows localized «Курьер»

## Test plan
- [ ] Login as courier → profile shows «Курьер»
- [ ] Reopen profile without extra /user request (role from cache)
- [ ] Logout clears role for next user