### PR TITLE
Show total user count on statistic user screen

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -201,6 +201,7 @@
     <!-- STATISTIC USER -->
     <string name="title_statistic_user">Статистика. Пользователи</string>
     <string name="title_statistic_user_details">Выбранный пользователь</string>
+    <string name="msg_statistic_user_total">Пользователей: %1$d</string>
     <string name="hint_statistic_user_search">Номер телефона</string>
     <string name="hint_statistic_user_first_order_date">Дата первого заказа</string>
     <string name="hint_statistic_user_last_order_date">Дата последнего заказа</string>

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserRoute.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserRoute.kt
@@ -35,6 +35,7 @@ import fooddeliveryadmin.shared.generated.resources.Res
 import fooddeliveryadmin.shared.generated.resources.hint_statistic_user_search
 import fooddeliveryadmin.shared.generated.resources.ic_search
 import fooddeliveryadmin.shared.generated.resources.msg_common_check_connection_and_retry
+import fooddeliveryadmin.shared.generated.resources.msg_statistic_user_total
 import fooddeliveryadmin.shared.generated.resources.title_common_can_not_load_data
 import fooddeliveryadmin.shared.generated.resources.title_menu_list_search_empty
 import fooddeliveryadmin.shared.generated.resources.title_statistic_user
@@ -147,6 +148,19 @@ private fun StatisticUserScreen(
                 Column(
                     modifier = Modifier.fillMaxSize(),
                 ) {
+                    Text(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                        text =
+                            stringResource(
+                                Res.string.msg_statistic_user_total,
+                                currentState.totalUsers,
+                            ),
+                        style = AdminTheme.typography.bodyLarge,
+                        color = AdminTheme.colors.main.onSurface,
+                    )
                     if (currentState.isSearchEnabled) {
                         StatisticUserSearchField(
                             searchQuery = currentState.searchQuery,
@@ -360,6 +374,7 @@ private fun StatisticUserScreenPreview() {
                                         phoneNumber = "+7 996 922 41 87",
                                     ),
                                 ),
+                            totalUsers = 2,
                             isSearchEnabled = false,
                             searchQuery = "",
                             searchResultList = null,

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserViewState.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserViewState.kt
@@ -18,6 +18,7 @@ data class StatisticUserViewState(
 
         data class Success(
             val users: ImmutableList<UserItem>,
+            val totalUsers: Int,
             val isSearchEnabled: Boolean,
             val searchQuery: String,
             val searchResultList: ImmutableList<UserItem>?,
@@ -47,6 +48,7 @@ internal fun StatisticUser.DataState.toViewState(): StatisticUserViewState =
                             users
                                 .map { user -> user.toItem() }
                                 .toPersistentList(),
+                        totalUsers = total,
                         isSearchEnabled = isSearchEnabled,
                         searchQuery = searchQuery,
                         searchResultList = getSearchResultList(),


### PR DESCRIPTION
## Summary
Shows the total number of users on the statistic user screen.

- Maps `DataState.total` (from GET `/client/list` `count`) into `ViewState.totalUsers`
- Displays total via `msg_statistic_user_total` above the user list

## How to test
1. Open **Профиль → Статистика пользователя**
2. Wait for the user list to load
3. Verify the text **«Пользователей: N»** appears above the list, where N matches the total from the API (not just the loaded page size)
4. Optionally scroll / load more pages and confirm the total stays the same