### PR TITLE
Add isProblematic to client user statistic

### DIFF
--- a/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserStatisticMapper.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserStatisticMapper.kt
@@ -13,5 +13,6 @@ class ClientUserStatisticMapper {
             pickupOrderCount = clientUserStatisticServer.pickupOrderCount,
             orderCount = clientUserStatisticServer.orderCount,
             averageCheck = clientUserStatisticServer.averageCheck,
+            isProblematic = clientUserStatisticServer.isProblematic,
         )
 }

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserStatisticServer.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserStatisticServer.kt
@@ -11,4 +11,5 @@ data class ClientUserStatisticServer(
     val pickupOrderCount: Int,
     val orderCount: Int,
     val averageCheck: Double,
+    val isProblematic: Boolean,
 )

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserStatistic.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserStatistic.kt
@@ -8,4 +8,5 @@ data class ClientUserStatistic(
     val pickupOrderCount: Int,
     val orderCount: Int,
     val averageCheck: Double,
+    val isProblematic: Boolean,
 )

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserRoute.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/statisticuser/StatisticUserRoute.kt
@@ -122,11 +122,12 @@ private fun StatisticUserScreen(
             if (state.state is StatisticUserViewState.State.Success) {
                 listOf(
                     AdminTopBarAction(
-                        iconId = if (state.state.isSearchEnabled) {
-                            Res.drawable.ic_close
-                        } else {
-                            Res.drawable.ic_search
-                        },
+                        iconId =
+                            if (state.state.isSearchEnabled) {
+                                Res.drawable.ic_close
+                            } else {
+                                Res.drawable.ic_search
+                            },
                         color = AdminTheme.colors.main.primary,
                         onClick = {
                             onAction(StatisticUser.Action.SearchClick)
@@ -156,7 +157,6 @@ private fun StatisticUserScreen(
                 Column(
                     modifier = Modifier.fillMaxSize(),
                 ) {
-
                     if (currentState.isSearchEnabled) {
                         StatisticUserSearchField(
                             searchQuery = currentState.searchQuery,
@@ -196,7 +196,7 @@ private fun StatisticUserSuccessContent(
                 },
                 modifier = modifier,
                 userCount = state.totalUsers,
-                isSearch = state.isSearchEnabled
+                isSearch = state.isSearchEnabled,
             )
         }
 
@@ -217,7 +217,7 @@ private fun StatisticUserSuccessContent(
                 },
                 modifier = modifier,
                 userCount = state.totalUsers,
-                isSearch = state.isSearchEnabled
+                isSearch = state.isSearchEnabled,
             )
         }
     }


### PR DESCRIPTION
## Summary
Прокинуто поле `isProblematic` из GET `/client/statistic` в admin: domain model, server DTO и mapper.

## How to test
1. Вызвать `GetClientUserStatisticUseCase` / открыть экран статистики клиента.
2. Убедиться, что `isProblematic` приходит с бэка и мапится в domain.