### PR TITLE
Add client personal discount data/domain layer

### DIFF
--- a/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/FoodDeliveryApi.kt
@@ -19,6 +19,7 @@ import com.bunbeauty.data.model.server.category.PatchCategoryList
 import com.bunbeauty.data.model.server.city.CityServer
 import com.bunbeauty.data.model.server.clientuser.ClientUserSettingsServer
 import com.bunbeauty.data.model.server.clientuser.ClientUserStatisticServer
+import com.bunbeauty.data.model.server.clientuser.PatchClientUserDiscountServer
 import com.bunbeauty.data.model.server.clientuser.PatchClientUserProblematicServer
 import com.bunbeauty.data.model.server.company.CompanyPatchServer
 import com.bunbeauty.data.model.server.company.WorkInfoData
@@ -86,6 +87,12 @@ interface FoodDeliveryApi {
         token: String,
         clientUserUuid: String,
         patch: PatchClientUserProblematicServer,
+    ): ApiResult<ClientUserSettingsServer>
+
+    suspend fun patchClientUserDiscount(
+        token: String,
+        phoneNumber: String,
+        patch: PatchClientUserDiscountServer,
     ): ApiResult<ClientUserSettingsServer>
 
     // CAFE

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserSettingsMapper.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/mapper/clientuser/ClientUserSettingsMapper.kt
@@ -11,5 +11,6 @@ class ClientUserSettingsMapper {
             email = clientUserSettingsServer.email,
             isActive = clientUserSettingsServer.isActive,
             isProblematic = clientUserSettingsServer.isProblematic,
+            personalDiscountPercent = clientUserSettingsServer.personalDiscountPercent,
         )
 }

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserSettingsServer.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/ClientUserSettingsServer.kt
@@ -9,4 +9,5 @@ data class ClientUserSettingsServer(
     val email: String?,
     val isActive: Boolean,
     val isProblematic: Boolean = false,
+    val personalDiscountPercent: Int? = null,
 )

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/PatchClientUserDiscountServer.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/model/server/clientuser/PatchClientUserDiscountServer.kt
@@ -1,0 +1,8 @@
+package com.bunbeauty.data.model.server.clientuser
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PatchClientUserDiscountServer(
+    val percentDiscount: Int,
+)

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/ClientUserRepository.kt
@@ -3,6 +3,7 @@ package com.bunbeauty.data.repository
 import com.bunbeauty.data.FoodDeliveryApi
 import com.bunbeauty.data.mapper.clientuser.ClientUserSettingsMapper
 import com.bunbeauty.data.mapper.clientuser.ClientUserStatisticMapper
+import com.bunbeauty.data.model.server.clientuser.PatchClientUserDiscountServer
 import com.bunbeauty.data.model.server.clientuser.PatchClientUserProblematicServer
 import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettings
 import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettingsList
@@ -109,6 +110,31 @@ class ClientUserRepository(
 
             is ApiResult.Error -> {
                 throw Exception("client user update error")
+            }
+        }
+
+    override suspend fun updateClientUserDiscount(
+        token: String,
+        phoneNumber: String,
+        percentDiscount: Int,
+    ): ClientUserSettings =
+        when (
+            val result =
+                foodDeliveryApi.patchClientUserDiscount(
+                    token = token,
+                    phoneNumber = phoneNumber,
+                    patch =
+                        PatchClientUserDiscountServer(
+                            percentDiscount = percentDiscount,
+                        ),
+                )
+        ) {
+            is ApiResult.Success -> {
+                clientUserSettingsMapper.map(result.data)
+            }
+
+            is ApiResult.Error -> {
+                throw Exception("client user discount update error")
             }
         }
 }

--- a/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
+++ b/data/src/commonMain/kotlin/com/bunbeauty/data/repository/FoodDeliveryApiImpl.kt
@@ -21,6 +21,7 @@ import com.bunbeauty.data.model.server.category.PatchCategoryList
 import com.bunbeauty.data.model.server.city.CityServer
 import com.bunbeauty.data.model.server.clientuser.ClientUserSettingsServer
 import com.bunbeauty.data.model.server.clientuser.ClientUserStatisticServer
+import com.bunbeauty.data.model.server.clientuser.PatchClientUserDiscountServer
 import com.bunbeauty.data.model.server.clientuser.PatchClientUserProblematicServer
 import com.bunbeauty.data.model.server.company.CompanyPatchServer
 import com.bunbeauty.data.model.server.company.WorkInfoData
@@ -131,6 +132,18 @@ class FoodDeliveryApiImpl(
         patch(
             path = "client/problematic",
             parameters = listOf("uuid" to clientUserUuid),
+            body = patch,
+            token = token,
+        )
+
+    override suspend fun patchClientUserDiscount(
+        token: String,
+        phoneNumber: String,
+        patch: PatchClientUserDiscountServer,
+    ): ApiResult<ClientUserSettingsServer> =
+        patch(
+            path = "client/discount",
+            parameters = listOf("phoneNumber" to phoneNumber),
             body = patch,
             token = token,
         )

--- a/docs/patch-client-discount.md
+++ b/docs/patch-client-discount.md
@@ -1,0 +1,149 @@
+# API: PATCH `/client/discount`
+
+Ручка уже есть / будет на бэкенде (`backPapa`). Документ — контракт для реализации на **FoodDeliveryAdmin**.
+
+**Назначение:** менеджер/админ выставляет клиенту персональную скидку (`percentDiscount`) или сбрасывает её (`0`).
+
+**Права:** JWT с ролью `MANAGER`, `COURIER` или `ADMIN`.
+
+---
+
+## Запрос
+
+| | |
+|---|---|
+| **Method** | `PATCH` |
+| **Path** | `/client/discount` |
+| **Auth** | `Authorization: Bearer <token>` |
+| **Query** | `phoneNumber` — телефон клиента в формате `+7XXXXXXXXXX` (обязательный) |
+
+### Body
+
+```json
+{
+  "percentDiscount": 15
+}
+```
+
+| Поле | Тип | Обязательное | Описание |
+|------|-----|--------------|----------|
+| `percentDiscount` | `Int` | да | `1..99` — установить скидку; `0` — очистить персональную скидку |
+
+Модель на бэке / в admin data: `PatchClientUserDiscount` / `PatchClientUserDiscountServer`.
+
+### Пример
+
+```http
+PATCH /client/discount?phoneNumber=+79001234567
+Authorization: Bearer <manager_jwt>
+Content-Type: application/json
+
+{
+  "percentDiscount": 15
+}
+```
+
+---
+
+## Ответ
+
+**HTTP 200** — тело `GetClientSettings` (без обёртки list):
+
+```json
+{
+  "uuid": "11111111-1111-1111-1111-111111111111",
+  "phoneNumber": "+79001234567",
+  "email": "user@example.com",
+  "isActive": true,
+  "isProblematic": false,
+  "personalDiscountPercent": 15
+}
+```
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `uuid` | `String` | UUID клиента |
+| `phoneNumber` | `String` | Телефон |
+| `email` | `String?` | Email |
+| `isActive` | `Boolean` | Активен ли клиент |
+| `isProblematic` | `Boolean` | Флаг проблемного клиента |
+| `personalDiscountPercent` | `Int?` | Персональная скидка после обновления; `null` если очищена |
+
+По форме совпадает с элементом списка `GET /client/list` / `GET /client/search`, плюс поле `personalDiscountPercent`.
+
+---
+
+## Ошибки
+
+| Код | Когда |
+|-----|--------|
+| **401** | Нет / невалидный JWT |
+| **403** | Роль не manager/courier/admin (например, client) |
+| **400** | Нет query `phoneNumber`, битый body, `percentDiscount` вне `0..99`, прочие ошибки |
+| **404** | Клиент не найден **или** клиент из другой компании менеджера (бэкенд маскирует mismatch как not found) |
+
+Проверка компании: `company` менеджера из JWT должна совпадать с `company` клиента.
+
+---
+
+## Бизнес-логика (кратко)
+
+1. По JWT менеджера берётся `companyUuid`.
+2. По `phoneNumber` находится клиент этой компании.
+3. Обновляется персональная скидка:
+   - `1..99` — сохранить значение;
+   - `0` — очистить (`personalDiscountPercent = null`).
+4. Возвращается обновлённый `GetClientSettings` с полем `personalDiscountPercent`.
+
+### Семантика скидки
+
+- **Разовая (one-time):** персональная скидка действует на один успешный заказ.
+- **Приоритет:** персональная скидка имеет приоритет над скидкой компании на первый заказ (`company.percentDiscount`).
+- **Очистка:** `percentDiscount = 0` снимает персональную скидку.
+- **Списание:** после успешного создания заказа персональная скидка считается использованной и очищается на бэкенде.
+
+Связанные ручки (уже используются в admin):
+
+- `GET /client/list` → список `GetClientSettings`
+- `GET /client/search?query=` → поиск
+- `GET /client/statistic?uuid=` → статистика
+- `PATCH /client/problematic` → флаг проблемного клиента
+
+---
+
+## Чеклист реализации (Admin)
+
+### Data
+
+1. Добавить `personalDiscountPercent: Int? = null` в `ClientUserSettingsServer` и domain `ClientUserSettings` (+ mapper).
+2. Request-модель `PatchClientUserDiscountServer(percentDiscount: Int)`.
+3. В `FoodDeliveryApi` / `FoodDeliveryApiImpl`:
+
+```kotlin
+suspend fun patchClientUserDiscount(
+    token: String,
+    phoneNumber: String,
+    patch: PatchClientUserDiscountServer,
+): ApiResult<ClientUserSettingsServer>
+```
+
+```kotlin
+patch(
+    path = "client/discount",
+    parameters = listOf("phoneNumber" to phoneNumber),
+    body = patch,
+    token = token,
+)
+```
+
+4. Метод в `ClientUserRepo` / `ClientUserRepository`.
+
+### Domain
+
+5. Валидации: телефон `^\+7[0-9]{10}$`, процент `0..99`.
+6. Use case: обновить скидку по `phoneNumber` + `percentDiscount`, вернуть обновлённые settings.
+
+### Presentation / UI
+
+7. Точка вызова: экран статистики клиента / список клиентов — поле ввода процента и действие «сохранить / сбросить».
+8. После успеха обновить локальный стейт (`personalDiscountPercent` в settings / списке).

--- a/domain/src/androidUnitTest/kotlin/feature/clientuser/UpdateClientUserDiscountUseCaseTest.kt
+++ b/domain/src/androidUnitTest/kotlin/feature/clientuser/UpdateClientUserDiscountUseCaseTest.kt
@@ -1,0 +1,153 @@
+package test.feature.clientuser
+
+import com.bunbeauty.domain.exception.NoTokenException
+import com.bunbeauty.domain.feature.clientuser.UpdateClientUserDiscountUseCase
+import com.bunbeauty.domain.feature.clientuser.exception.ClientPhoneNumberException
+import com.bunbeauty.domain.feature.clientuser.exception.PercentDiscountException
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettings
+import com.bunbeauty.domain.feature.clientuser.validation.ValidateClientPhoneNumberUseCase
+import com.bunbeauty.domain.feature.clientuser.validation.ValidatePercentDiscountUseCase
+import com.bunbeauty.domain.repo.ClientUserRepo
+import com.bunbeauty.domain.repo.DataStoreRepo
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UpdateClientUserDiscountUseCaseTest {
+    private val clientUserRepo: ClientUserRepo = mockk()
+    private val dataStoreRepo: DataStoreRepo = mockk()
+    private val updateClientUserDiscountUseCase =
+        UpdateClientUserDiscountUseCase(
+            clientUserRepo = clientUserRepo,
+            dataStoreRepo = dataStoreRepo,
+            validateClientPhoneNumberUseCase = ValidateClientPhoneNumberUseCase(),
+            validatePercentDiscountUseCase = ValidatePercentDiscountUseCase(),
+        )
+
+    @Test
+    fun `invoke returns updated settings when token exists`() =
+        runTest {
+            val token = "valid_token"
+            val phoneNumber = "+79001234567"
+            val percentDiscount = 15
+            val updatedSettings =
+                ClientUserSettings(
+                    uuid = "client-uuid",
+                    phoneNumber = phoneNumber,
+                    email = "user@example.com",
+                    isActive = true,
+                    isProblematic = false,
+                    personalDiscountPercent = percentDiscount,
+                )
+
+            coEvery { dataStoreRepo.getToken() } returns token
+            coEvery {
+                clientUserRepo.updateClientUserDiscount(
+                    token = token,
+                    phoneNumber = phoneNumber,
+                    percentDiscount = percentDiscount,
+                )
+            } returns updatedSettings
+
+            val result =
+                updateClientUserDiscountUseCase(
+                    phoneNumber = "  $phoneNumber  ",
+                    percentDiscount = percentDiscount,
+                )
+
+            assertEquals(updatedSettings, result)
+            coVerify {
+                clientUserRepo.updateClientUserDiscount(
+                    token = token,
+                    phoneNumber = phoneNumber,
+                    percentDiscount = percentDiscount,
+                )
+            }
+            coVerify { dataStoreRepo.getToken() }
+        }
+
+    @Test
+    fun `invoke throws NoTokenException when token is null`() =
+        runTest {
+            coEvery { dataStoreRepo.getToken() } returns null
+
+            assertFailsWith<NoTokenException> {
+                updateClientUserDiscountUseCase(
+                    phoneNumber = "+79001234567",
+                    percentDiscount = 15,
+                )
+            }
+
+            coVerify(exactly = 0) {
+                clientUserRepo.updateClientUserDiscount(
+                    token = any(),
+                    phoneNumber = any(),
+                    percentDiscount = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `invoke throws ClientPhoneNumberException when phone is invalid`() =
+        runTest {
+            assertFailsWith<ClientPhoneNumberException> {
+                updateClientUserDiscountUseCase(
+                    phoneNumber = "89001234567",
+                    percentDiscount = 15,
+                )
+            }
+
+            coVerify(exactly = 0) { dataStoreRepo.getToken() }
+            coVerify(exactly = 0) {
+                clientUserRepo.updateClientUserDiscount(
+                    token = any(),
+                    phoneNumber = any(),
+                    percentDiscount = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `invoke throws PercentDiscountException when percent is negative`() =
+        runTest {
+            assertFailsWith<PercentDiscountException> {
+                updateClientUserDiscountUseCase(
+                    phoneNumber = "+79001234567",
+                    percentDiscount = -1,
+                )
+            }
+
+            coVerify(exactly = 0) { dataStoreRepo.getToken() }
+            coVerify(exactly = 0) {
+                clientUserRepo.updateClientUserDiscount(
+                    token = any(),
+                    phoneNumber = any(),
+                    percentDiscount = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `invoke throws PercentDiscountException when percent is 100`() =
+        runTest {
+            assertFailsWith<PercentDiscountException> {
+                updateClientUserDiscountUseCase(
+                    phoneNumber = "+79001234567",
+                    percentDiscount = 100,
+                )
+            }
+
+            coVerify(exactly = 0) { dataStoreRepo.getToken() }
+            coVerify(exactly = 0) {
+                clientUserRepo.updateClientUserDiscount(
+                    token = any(),
+                    phoneNumber = any(),
+                    percentDiscount = any(),
+                )
+            }
+        }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/UpdateClientUserDiscountUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/UpdateClientUserDiscountUseCase.kt
@@ -1,0 +1,29 @@
+package com.bunbeauty.domain.feature.clientuser
+
+import com.bunbeauty.domain.exception.NoTokenException
+import com.bunbeauty.domain.feature.clientuser.model.ClientUserSettings
+import com.bunbeauty.domain.feature.clientuser.validation.ValidateClientPhoneNumberUseCase
+import com.bunbeauty.domain.feature.clientuser.validation.ValidatePercentDiscountUseCase
+import com.bunbeauty.domain.repo.ClientUserRepo
+import com.bunbeauty.domain.repo.DataStoreRepo
+
+class UpdateClientUserDiscountUseCase(
+    private val clientUserRepo: ClientUserRepo,
+    private val dataStoreRepo: DataStoreRepo,
+    private val validateClientPhoneNumberUseCase: ValidateClientPhoneNumberUseCase,
+    private val validatePercentDiscountUseCase: ValidatePercentDiscountUseCase,
+) {
+    suspend operator fun invoke(
+        phoneNumber: String,
+        percentDiscount: Int,
+    ): ClientUserSettings {
+        val validatedPhoneNumber = validateClientPhoneNumberUseCase(phoneNumber)
+        val validatedPercentDiscount = validatePercentDiscountUseCase(percentDiscount)
+
+        return clientUserRepo.updateClientUserDiscount(
+            token = dataStoreRepo.getToken() ?: throw NoTokenException(),
+            phoneNumber = validatedPhoneNumber,
+            percentDiscount = validatedPercentDiscount,
+        )
+    }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/exception/ClientPhoneNumberException.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/exception/ClientPhoneNumberException.kt
@@ -1,0 +1,3 @@
+package com.bunbeauty.domain.feature.clientuser.exception
+
+class ClientPhoneNumberException : Exception()

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/exception/PercentDiscountException.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/exception/PercentDiscountException.kt
@@ -1,0 +1,3 @@
+package com.bunbeauty.domain.feature.clientuser.exception
+
+class PercentDiscountException : Exception()

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettings.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/model/ClientUserSettings.kt
@@ -6,4 +6,5 @@ data class ClientUserSettings(
     val email: String?,
     val isActive: Boolean,
     val isProblematic: Boolean = false,
+    val personalDiscountPercent: Int? = null,
 )

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/validation/ValidateClientPhoneNumberUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/validation/ValidateClientPhoneNumberUseCase.kt
@@ -1,0 +1,18 @@
+package com.bunbeauty.domain.feature.clientuser.validation
+
+import com.bunbeauty.domain.feature.clientuser.exception.ClientPhoneNumberException
+
+class ValidateClientPhoneNumberUseCase {
+    operator fun invoke(phoneNumber: String): String {
+        val trimmedPhoneNumber = phoneNumber.trim()
+        if (PHONE_NUMBER_REGEX.matches(trimmedPhoneNumber)) {
+            return trimmedPhoneNumber
+        } else {
+            throw ClientPhoneNumberException()
+        }
+    }
+
+    private companion object {
+        val PHONE_NUMBER_REGEX = Regex("""^\+7[0-9]{10}$""")
+    }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/validation/ValidatePercentDiscountUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/feature/clientuser/validation/ValidatePercentDiscountUseCase.kt
@@ -1,0 +1,18 @@
+package com.bunbeauty.domain.feature.clientuser.validation
+
+import com.bunbeauty.domain.feature.clientuser.exception.PercentDiscountException
+
+class ValidatePercentDiscountUseCase {
+    operator fun invoke(percentDiscount: Int): Int {
+        if (percentDiscount in MIN_PERCENT_DISCOUNT..MAX_PERCENT_DISCOUNT) {
+            return percentDiscount
+        } else {
+            throw PercentDiscountException()
+        }
+    }
+
+    private companion object {
+        const val MIN_PERCENT_DISCOUNT = 0
+        const val MAX_PERCENT_DISCOUNT = 99
+    }
+}

--- a/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
+++ b/domain/src/commonMain/kotlin/com/bunbeauty/domain/repo/ClientUserRepo.kt
@@ -28,4 +28,10 @@ interface ClientUserRepo {
         clientUserUuid: String,
         isProblematic: Boolean,
     ): ClientUserSettings
+
+    suspend fun updateClientUserDiscount(
+        token: String,
+        phoneNumber: String,
+        percentDiscount: Int,
+    ): ClientUserSettings
 }

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/UseCaseModule.kt
@@ -4,7 +4,10 @@ import com.bunbeauty.domain.feature.additiongrouplist.createadditiongrouplist.Cr
 import com.bunbeauty.domain.feature.clientuser.GetClientUserListUseCase
 import com.bunbeauty.domain.feature.clientuser.GetClientUserSearchUseCase
 import com.bunbeauty.domain.feature.clientuser.GetClientUserStatisticUseCase
+import com.bunbeauty.domain.feature.clientuser.UpdateClientUserDiscountUseCase
 import com.bunbeauty.domain.feature.clientuser.UpdateClientUserProblematicUseCase
+import com.bunbeauty.domain.feature.clientuser.validation.ValidateClientPhoneNumberUseCase
+import com.bunbeauty.domain.feature.clientuser.validation.ValidatePercentDiscountUseCase
 import com.bunbeauty.domain.feature.common.GetCafeUseCase
 import com.bunbeauty.domain.feature.menu.additiongroupformenuproduct.editadditiongroupformenuproduct.SaveEditAdditionGroupWithAdditionsUseCase
 import com.bunbeauty.domain.feature.menu.common.category.CreateCategoryUseCase
@@ -84,6 +87,23 @@ fun useCaseModule() =
             UpdateClientUserProblematicUseCase(
                 clientUserRepo = get(),
                 dataStoreRepo = get(),
+            )
+        }
+
+        factory {
+            ValidateClientPhoneNumberUseCase()
+        }
+
+        factory {
+            ValidatePercentDiscountUseCase()
+        }
+
+        factory {
+            UpdateClientUserDiscountUseCase(
+                clientUserRepo = get(),
+                dataStoreRepo = get(),
+                validateClientPhoneNumberUseCase = get(),
+                validatePercentDiscountUseCase = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsRoute.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/feature/order/OrderDetailsRoute.kt
@@ -35,7 +35,6 @@ import com.bunbeauty.shared.designsystem.compose.bottomBarPadding
 import com.bunbeauty.shared.designsystem.compose.element.bottomsheet.AdminModalBottomSheet
 import com.bunbeauty.shared.designsystem.compose.element.button.LoadingButton
 import com.bunbeauty.shared.designsystem.compose.element.button.SecondaryButton
-import com.bunbeauty.shared.designsystem.compose.element.card.AdminCard
 import com.bunbeauty.shared.designsystem.compose.element.card.DiscountCard
 import com.bunbeauty.shared.designsystem.compose.element.card.NavigationIconCard
 import com.bunbeauty.shared.designsystem.compose.element.card.StatusNavigationTextCard


### PR DESCRIPTION
## Summary
- Add PATCH client discount by phoneNumber in Data (API, DTO, repository) and Domain (`UpdateClientUserDiscountUseCase`, validations, exceptions).
- Add `personalDiscountPercent` to `ClientUserSettings` (server model + mapper).
- Wire use cases in `UseCaseModule`; add unit tests and `docs/patch-client-discount.md`.
- Presentation/UI not changed in this PR.

## Test plan
- [ ] Run `UpdateClientUserDiscountUseCaseTest`
- [ ] Verify discount validations (phone number, percent bounds)
- [ ] Smoke-check API mapping for `personalDiscountPercent` on client settings response
- [ ] Confirm no UI/presentation changes required for merge